### PR TITLE
Fix crash with Fabric API 0.50

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 16
+          java-version: 17
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Use gradle cache for faster builds

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.18.2
 yarn_mappings=1.18.2+build.2
 loader_version=0.13.3
 #Fabric api
-fabric_version=0.48.0+1.18.2
+fabric_version=0.50.0+1.18.2
 # Mod Properties
 mod_version=1.5.0
 maven_group=me.steven

--- a/src/main/java/me/steven/wirelessnetworks/WirelessNetworks.java
+++ b/src/main/java/me/steven/wirelessnetworks/WirelessNetworks.java
@@ -8,14 +8,14 @@ import me.steven.wirelessnetworks.network.ExposedNetwork;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
-import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
-import net.fabricmc.fabric.impl.screenhandler.ExtendedScreenHandlerType;
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
 import net.minecraft.block.Block;
 import net.minecraft.block.Material;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -36,30 +36,32 @@ public class WirelessNetworks implements ModInitializer {
 			= FabricBlockEntityTypeBuilder.create(NetworkNodeBlockEntity::new, NODE_BLOCK).build(null);
 	public static final Item ENTANGLED_CAPACITOR_ITEM = new Item(new Item.Settings().group(ItemGroup.SEARCH));
 
-	public static final ExtendedScreenHandlerType<NetworkNodeScreen> NODE_SCREEN_TYPE = (ExtendedScreenHandlerType<NetworkNodeScreen>)
-			ScreenHandlerRegistry.registerExtended(new Identifier(MOD_ID, "node_screen"), (syncId, inventory, buf) -> {
-				BlockPos blockPos = buf.readBlockPos();
-				boolean input = buf.readBoolean();
-				int size = buf.readInt();
-				List<String> keys = new ArrayList<>();
-				for (int index = 0; index < size; index++) {
-					keys.add(buf.readString(32767));
-				}
-				return new NetworkNodeScreen(blockPos, input, keys, syncId, inventory);
-			});
+	public static final ScreenHandlerType<NetworkNodeScreen> NODE_SCREEN_TYPE = Registry.register(
+		Registry.SCREEN_HANDLER, new Identifier(MOD_ID, "node_screen"), new ExtendedScreenHandlerType<>((syncId, inventory, buf) -> {
+			BlockPos blockPos = buf.readBlockPos();
+			boolean input = buf.readBoolean();
+			int size = buf.readInt();
+			List<String> keys = new ArrayList<>();
+			for (int index = 0; index < size; index++) {
+				keys.add(buf.readString(32767));
+			}
+			return new NetworkNodeScreen(blockPos, input, keys, syncId, inventory);
+		})
+	);
 
-	public static final ExtendedScreenHandlerType<NetworkConfigureScreen> CONFIGURE_SCREEN_TYPE = (ExtendedScreenHandlerType<NetworkConfigureScreen>)
-			ScreenHandlerRegistry.registerExtended(new Identifier(MOD_ID, "configure_node_screen"), (syncId, inventory, buf) -> {
-				BlockPos pos = buf.readBlockPos();
-				boolean isNewNetwork = buf.readBoolean();
-				String networkId = isNewNetwork ? null : buf.readString(32767);
-				long energyCapacity = buf.readLong();
-				long maxInput = buf.readLong();
-				long maxOutput = buf.readLong();
-				boolean isProtected = buf.readBoolean();
-				UUID owner = buf.readUuid();
-				return new NetworkConfigureScreen(pos, networkId, owner, isProtected, energyCapacity, maxInput, maxOutput, syncId, inventory);
-			});
+	public static final ScreenHandlerType<NetworkConfigureScreen> CONFIGURE_SCREEN_TYPE = Registry.register(
+		Registry.SCREEN_HANDLER, new Identifier(MOD_ID, "configure_node_screen"), new ExtendedScreenHandlerType<>((syncId, inventory, buf) -> {
+			BlockPos pos = buf.readBlockPos();
+			boolean isNewNetwork = buf.readBoolean();
+			String networkId = isNewNetwork ? null : buf.readString(32767);
+			long energyCapacity = buf.readLong();
+			long maxInput = buf.readLong();
+			long maxOutput = buf.readLong();
+			boolean isProtected = buf.readBoolean();
+			UUID owner = buf.readUuid();
+			return new NetworkConfigureScreen(pos, networkId, owner, isProtected, energyCapacity, maxInput, maxOutput, syncId, inventory);
+		})
+	);
 
 	@Override
 	public void onInitialize() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "fabric": "*",
-    "minecraft": "1.18.x"
+    "fabric": ">=0.50",
+    "minecraft": "~1.18.2"
   }
 }


### PR DESCRIPTION
Though changing the type from `ExtendedScreenHandlerType` to regular `ScreenHandlerType` is enough (it might also keep1.18.1 compat, not sure) but I hate deprecated errors :p